### PR TITLE
Add ChatGPT integration to Flutter app

### DIFF
--- a/flutter_chat_app/lib/screens/chat_screen.dart
+++ b/flutter_chat_app/lib/screens/chat_screen.dart
@@ -116,7 +116,7 @@ class _ChatScreenState extends State<ChatScreen> {
                       Padding(
                         padding: const EdgeInsets.all(12.0),
                         child: Text(
-                          'Online Users (${chatProvider.onlineUsers.length})',
+                          'Contacts (${chatProvider.availableUsers.length})',
                           style: theme.textTheme.titleLarge?.copyWith(
                             fontSize: 18,
                             color: theme.colorScheme.primary,
@@ -124,25 +124,13 @@ class _ChatScreenState extends State<ChatScreen> {
                         ),
                       ),
                       Expanded(
-                        child:
-                            chatProvider.isConnected &&
-                                chatProvider.onlineUsers.isNotEmpty
-                            ? ListView.builder(
-                                itemCount: chatProvider.onlineUsers.length,
-                                itemBuilder: (context, index) {
-                                  final userId =
-                                      chatProvider.onlineUsers[index];
-                                  return UserListTile(userId: userId);
-                                },
-                              )
-                            : Center(
-                                child: Text(
-                                  chatProvider.isConnected
-                                      ? 'No other users online'
-                                      : 'Not Connected',
-                                  style: theme.textTheme.bodyMedium,
-                                ),
-                              ),
+                        child: ListView.builder(
+                          itemCount: chatProvider.availableUsers.length,
+                          itemBuilder: (context, index) {
+                            final userId = chatProvider.availableUsers[index];
+                            return UserListTile(userId: userId);
+                          },
+                        ),
                       ),
                     ],
                   ),
@@ -179,7 +167,9 @@ class _ChatScreenState extends State<ChatScreen> {
                       ),
                       // Message input area
                       if (chatProvider.selectedChatUserId != null &&
-                          chatProvider.isConnected)
+                          (chatProvider.isConnected ||
+                              chatProvider.selectedChatUserId ==
+                                  chatProvider.chatGptUserId))
                         Padding(
                           padding: const EdgeInsets.all(10.0),
                           child: Row(

--- a/flutter_chat_app/lib/services/gpt_service.dart
+++ b/flutter_chat_app/lib/services/gpt_service.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class GptService {
+  final String apiKey;
+  final String apiUrl;
+
+  const GptService({required this.apiKey, this.apiUrl = 'https://api.openai.com/v1/chat/completions'});
+
+  Future<String> sendMessage(List<Map<String, String>> messages) async {
+    final response = await http.post(
+      Uri.parse(apiUrl),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $apiKey',
+      },
+      body: jsonEncode({
+        'model': 'gpt-3.5-turbo',
+        'messages': messages,
+      }),
+    );
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body);
+      return data['choices'][0]['message']['content'] as String;
+    } else {
+      throw Exception('GPT request failed: ${response.body}');
+    }
+  }
+}

--- a/flutter_chat_app/pubspec.yaml
+++ b/flutter_chat_app/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
     sdk: flutter
   provider: ^6.0.0             # 状态管理
   web_socket_channel: ^2.4.0   # WebSocket 通信
+  http: ^1.1.0                 # HTTP requests for ChatGPT
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8


### PR DESCRIPTION
## Summary
- add HTTP dependency for API access
- create `GptService` to call OpenAI
- extend `ChatProvider` to support a `ChatGPT` contact
- update chat screen to list ChatGPT and allow chatting without server connection

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653459b5708322b1d8e039d24bbc72